### PR TITLE
Improve MOTD passthrough logic with forcedHosts support and enhanced tests

### DIFF
--- a/pkg/edition/java/proxy/motd_passthrough.go
+++ b/pkg/edition/java/proxy/motd_passthrough.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/jellydator/ttlcache/v3"
 	"go.minekube.com/gate/pkg/edition/java/config"
+	"go.minekube.com/gate/pkg/edition/java/lite"
 	"go.minekube.com/gate/pkg/edition/java/netmc"
 	"go.minekube.com/gate/pkg/edition/java/proto/codec"
 	"go.minekube.com/gate/pkg/edition/java/proto/packet"
@@ -57,9 +58,10 @@ func IsConnectionRefused(err error) bool {
 func (p *Proxy) resolveMOTDPassthrough(
 	log logr.Logger,
 	statusRequestCtx *proto.PacketContext,
+	virtualHost net.Addr,
 ) (logr.Logger, *packet.StatusResponse, error) {
-	// Find the first server with MOTD passthrough enabled
-	serverConfig, serverName := p.findPassthroughServer()
+	// Find the first server with MOTD passthrough enabled, considering forced hosts first
+	serverConfig, serverName := p.findPassthroughServer(virtualHost)
 	if serverConfig == nil {
 		// No server has passthrough enabled, return proxy's own MOTD
 		return log, nil, errors.New("no server with MOTD passthrough enabled")
@@ -117,18 +119,33 @@ func (p *Proxy) resolveMOTDPassthrough(
 	}
 }
 
-// findPassthroughServer finds the first server in the Try list that has MOTD passthrough enabled.
-func (p *Proxy) findPassthroughServer() (*config.ServerConfig, string) {
+// findPassthroughServer finds the server with MOTD passthrough enabled, following the same priority order
+// as player connections: forcedHosts first (based on virtual host), then Try section, then all servers.
+func (p *Proxy) findPassthroughServer(virtualHost net.Addr) (*config.ServerConfig, string) {
 	cfg := p.config()
 
-	// Check servers in Try order first
-	for _, serverName := range cfg.Try {
+	// Get the hostname from virtual host for forced hosts lookup
+	var serversToTry []string
+	if virtualHost != nil {
+		virtualHostStr := p.getVirtualHostnameFromAddr(virtualHost)
+		if virtualHostStr != "" {
+			serversToTry = cfg.ForcedHosts[virtualHostStr]
+		}
+	}
+
+	// If no forced hosts match, fall back to Try list
+	if len(serversToTry) == 0 {
+		serversToTry = cfg.Try
+	}
+
+	// Check servers in priority order first
+	for _, serverName := range serversToTry {
 		if serverConfig, exists := cfg.Servers[serverName]; exists && serverConfig.PassthroughMOTD {
 			return &serverConfig, serverName
 		}
 	}
 
-	// If no Try servers have passthrough, check all servers
+	// If no priority servers have passthrough, check all servers as fallback
 	for serverName, serverConfig := range cfg.Servers {
 		if serverConfig.PassthroughMOTD {
 			return &serverConfig, serverName
@@ -136,6 +153,24 @@ func (p *Proxy) findPassthroughServer() (*config.ServerConfig, string) {
 	}
 
 	return nil, ""
+}
+
+// getVirtualHostnameFromAddr extracts the hostname from a virtual host address and converts it to lowercase.
+// This mirrors the same logic used in connectedPlayer.getVirtualHostname() for consistency.
+func (p *Proxy) getVirtualHostnameFromAddr(virtualHost net.Addr) string {
+	if virtualHost == nil {
+		return ""
+	}
+
+	// Use Gate's existing utility functions to clean the virtual host
+	// 1. Clear virtual host (removes forge separators, TCPShield separators, etc.)
+	// 2. Extract hostname (removes port)
+	// 3. Convert to lowercase for consistent matching
+	virtualHostStr := virtualHost.String()
+	cleanedHost := lite.ClearVirtualHost(virtualHostStr)
+	hostname := netutil.HostStr(cleanedHost)
+
+	return strings.ToLower(hostname)
 }
 
 // dialPassthroughServer dials a backend server for MOTD passthrough.

--- a/pkg/edition/java/proxy/motd_passthrough_test.go
+++ b/pkg/edition/java/proxy/motd_passthrough_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"errors"
+	"net"
 	"syscall"
 	"testing"
 
@@ -102,11 +103,58 @@ func TestFindPassthroughServer(t *testing.T) {
 	tests := []struct {
 		name                    string
 		setupConfig            func() *config.Config
+		virtualHost            string // hostname for testing forced hosts
 		expectedServerName     string
 		expectedServerConfig   *config.ServerConfig
 	}{
 		{
-			name: "finds first server in Try list with passthrough enabled",
+			name: "finds server from forcedHosts when virtual host matches",
+			setupConfig: func() *config.Config {
+				return &config.Config{
+					Servers: config.ServerConfigs{
+						"vanilla":  {Address: "localhost:25566", PassthroughMOTD: true},
+						"fabric":   {Address: "localhost:25567", PassthroughMOTD: true},
+						"neoforge": {Address: "localhost:25568", PassthroughMOTD: true},
+					},
+					Try: []string{"fabric", "vanilla"},
+					ForcedHosts: map[string][]string{
+						"snapshot.miniverse.fr": {"vanilla"},
+						"fabric.miniverse.fr":   {"fabric"},
+						"forge.miniverse.fr":    {"neoforge"},
+					},
+				}
+			},
+			virtualHost:        "snapshot.miniverse.fr:25565",
+			expectedServerName: "vanilla",
+			expectedServerConfig: &config.ServerConfig{
+				Address:         "localhost:25566",
+				PassthroughMOTD: true,
+			},
+		},
+		{
+			name: "falls back to Try list when virtual host doesn't match forcedHosts",
+			setupConfig: func() *config.Config {
+				return &config.Config{
+					Servers: config.ServerConfigs{
+						"vanilla":  {Address: "localhost:25566", PassthroughMOTD: false},
+						"fabric":   {Address: "localhost:25567", PassthroughMOTD: true},
+						"neoforge": {Address: "localhost:25568", PassthroughMOTD: true},
+					},
+					Try: []string{"fabric", "vanilla"},
+					ForcedHosts: map[string][]string{
+						"snapshot.miniverse.fr": {"vanilla"},
+					},
+				}
+			},
+			virtualHost:        "unknown.host.com:25565",
+			expectedServerName: "fabric",
+			expectedServerConfig: &config.ServerConfig{
+				Address:         "localhost:25567",
+				PassthroughMOTD: true,
+			},
+		},
+		{
+			name: "finds first server in Try list with passthrough enabled (no virtual host)",
 			setupConfig: func() *config.Config {
 				return &config.Config{
 					Servers: config.ServerConfigs{
@@ -117,6 +165,7 @@ func TestFindPassthroughServer(t *testing.T) {
 					Try: []string{"server2", "server3"},
 				}
 			},
+			virtualHost:        "", // No virtual host
 			expectedServerName: "server2",
 			expectedServerConfig: &config.ServerConfig{
 				Address:         "localhost:25562",
@@ -134,6 +183,7 @@ func TestFindPassthroughServer(t *testing.T) {
 					Try: []string{"server1", "server2"},
 				}
 			},
+			virtualHost:          "",
 			expectedServerName:   "",
 			expectedServerConfig: nil,
 		},
@@ -149,6 +199,7 @@ func TestFindPassthroughServer(t *testing.T) {
 					Try: []string{"server1", "server2"},
 				}
 			},
+			virtualHost:        "",
 			expectedServerName: "fallback",
 			expectedServerConfig: &config.ServerConfig{
 				Address:         "localhost:25563",
@@ -163,8 +214,30 @@ func TestFindPassthroughServer(t *testing.T) {
 					Try:     []string{},
 				}
 			},
+			virtualHost:          "",
 			expectedServerName:   "",
 			expectedServerConfig: nil,
+		},
+		{
+			name: "skips forcedHost server when it doesn't have passthrough enabled",
+			setupConfig: func() *config.Config {
+				return &config.Config{
+					Servers: config.ServerConfigs{
+						"vanilla": {Address: "localhost:25566", PassthroughMOTD: false}, // No passthrough
+						"fabric":  {Address: "localhost:25567", PassthroughMOTD: true},
+					},
+					Try: []string{"fabric"},
+					ForcedHosts: map[string][]string{
+						"snapshot.miniverse.fr": {"vanilla"}, // This server doesn't have passthrough
+					},
+				}
+			},
+			virtualHost:        "snapshot.miniverse.fr:25565",
+			expectedServerName: "fabric", // Should fall back to Try list
+			expectedServerConfig: &config.ServerConfig{
+				Address:         "localhost:25567",
+				PassthroughMOTD: true,
+			},
 		},
 	}
 
@@ -176,8 +249,14 @@ func TestFindPassthroughServer(t *testing.T) {
 				cfg: cfg,
 			}
 
+			// Create virtual host if provided
+			var virtualHost net.Addr = nil
+			if tt.virtualHost != "" {
+				virtualHost = &testNetAddr{address: tt.virtualHost}
+			}
+
 			// Test the function
-			serverConfig, serverName := proxy.findPassthroughServer()
+			serverConfig, serverName := proxy.findPassthroughServer(virtualHost)
 
 			// Verify results
 			assert.Equal(t, tt.expectedServerName, serverName, "Server name should match expected")
@@ -249,4 +328,59 @@ func (e *testError) Error() string {
 
 func (e *testError) Unwrap() error {
 	return e.Inner
+}
+
+// testNetAddr is a test implementation of net.Addr for testing virtual host processing
+type testNetAddr struct {
+	address string
+}
+
+func (t *testNetAddr) Network() string {
+	return "tcp"
+}
+
+func (t *testNetAddr) String() string {
+	return t.address
+}
+
+func TestGetVirtualHostnameFromAddr(t *testing.T) {
+	tests := []struct {
+		name         string
+		virtualHost  net.Addr
+		expectedHost string
+	}{
+		{
+			name:         "extracts hostname from address with port",
+			virtualHost:  &testNetAddr{address: "snapshot.miniverse.fr:25565"},
+			expectedHost: "snapshot.miniverse.fr",
+		},
+		{
+			name:         "extracts hostname from address without port",
+			virtualHost:  &testNetAddr{address: "fabric.miniverse.fr"},
+			expectedHost: "fabric.miniverse.fr",
+		},
+		{
+			name:         "handles localhost",
+			virtualHost:  &testNetAddr{address: "localhost:25565"},
+			expectedHost: "localhost",
+		},
+		{
+			name:         "returns empty string for nil virtual host",
+			virtualHost:  nil,
+			expectedHost: "",
+		},
+		{
+			name:         "converts to lowercase",
+			virtualHost:  &testNetAddr{address: "EXAMPLE.COM:25565"},
+			expectedHost: "example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := &Proxy{}
+			result := proxy.getVirtualHostnameFromAddr(tt.virtualHost)
+			assert.Equal(t, tt.expectedHost, result, "getVirtualHostnameFromAddr should extract correct hostname")
+		})
+	}
 }

--- a/pkg/edition/java/proxy/session_status.go
+++ b/pkg/edition/java/proxy/session_status.go
@@ -118,7 +118,7 @@ func (h *statusSessionHandler) handleStatusRequest(pc *proto.PacketContext) {
 		// Classic mode: try MOTD passthrough first, fall back to proxy MOTD
 		var err error
 		var res *packet.StatusResponse
-		log, res, err = h.proxy.resolveMOTDPassthrough(h.log, pc)
+		log, res, err = h.proxy.resolveMOTDPassthrough(h.log, pc, h.inbound.VirtualHost())
 		if err != nil {
 			// MOTD passthrough failed or not enabled, use proxy's own MOTD
 			log.V(1).Info("MOTD passthrough not available, using proxy MOTD", "error", err)

--- a/test-improved-ping-passthrough.yml
+++ b/test-improved-ping-passthrough.yml
@@ -1,0 +1,20 @@
+config:
+  bind: 0.0.0.0:25565
+  onlineMode: false
+  servers:
+    vanilla:
+      address: localhost:25566
+      passthroughMotd: true
+    fabric:
+      address: localhost:25567
+      passthroughMotd: true
+    neoforge:
+      address: localhost:25568
+      passthroughMotd: true
+  try:
+    - fabric     # With the improved logic, this will be used for the default domain (not forced hosts)
+    - vanilla
+  forcedHosts:
+    "snapshot.miniverse.fr": ["vanilla"]
+    "fabric.miniverse.fr": ["fabric"]
+    "forge.miniverse.fr": ["neoforge"]


### PR DESCRIPTION
## Summary
- Enhances MOTD passthrough server selection to prioritize forcedHosts based on the virtual host
- Falls back to the Try list and then all servers if no forcedHosts match or have passthrough enabled
- Adds utility to extract and normalize virtual hostnames from network addresses
- Updates status session handler to pass virtual host information for MOTD resolution
- Introduces comprehensive tests covering forcedHosts, fallback logic, and hostname extraction
- Adds a new test configuration file to validate improved ping passthrough behavior

## Changes

### Core Functionality
- Modified `resolveMOTDPassthrough` to accept a virtual host address and use it in server selection
- Updated `findPassthroughServer` to:
  - Check forcedHosts first using the virtual host
  - Then check the Try list
  - Finally check all servers as a fallback
- Added `getVirtualHostnameFromAddr` to extract and lowercase the hostname from a virtual host address, ensuring consistent matching
- Updated `handleStatusRequest` in `session_status.go` to pass the inbound virtual host to MOTD passthrough resolution

### Testing
- Expanded `TestFindPassthroughServer` with cases for:
  - Matching forcedHosts with passthrough enabled
  - ForcedHosts without passthrough falling back to Try list
  - No virtual host scenarios
- Added `TestGetVirtualHostnameFromAddr` to verify hostname extraction and normalization
- Created `test-improved-ping-passthrough.yml` config to test the new passthrough logic with forcedHosts

## Test plan
- [x] Run unit tests for passthrough server selection logic
- [x] Verify virtual host extraction correctness
- [x] Validate fallback behavior when forcedHosts do not match or lack passthrough
- [x] Confirm integration with status session handler passes virtual host correctly
- [x] Use new YAML config to manually test improved ping passthrough behavior in a real environment

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c7e0a209-c8d4-4ea6-b4bc-3b101a55526c