### PR TITLE
Fix console reader close to avoid blocking on Windows

### DIFF
--- a/pkg/gate/console_runner.go
+++ b/pkg/gate/console_runner.go
@@ -193,8 +193,21 @@ func (r *consoleRunner) printPrompt() {
 
 func (r *consoleRunner) closeReader() {
 	r.onceClose.Do(func() {
-		if r.reader != nil {
-			_ = r.reader.Close()
+		if r.reader == nil {
+			return
+		}
+
+		done := make(chan struct{})
+		// Closing the console reader can block on Windows for tens of seconds,
+		// so perform it asynchronously and only wait briefly.
+		go func(reader io.Closer) {
+			defer close(done)
+			_ = reader.Close()
+		}(r.reader)
+
+		select {
+		case <-done:
+		case <-time.After(250 * time.Millisecond):
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Prevents blocking when closing the console reader on Windows by performing the close operation asynchronously
- Adds a timeout of 250 milliseconds to avoid long delays during shutdown

## Changes

### Console Runner
- Modified `closeReader` method to:
  - Return early if the reader is nil
  - Close the reader asynchronously in a goroutine
  - Use a select statement to wait for either the close to complete or a 250ms timeout

## Test plan
- Verified that closing the console reader does not block shutdown on Windows
- Ensured no regressions in console input handling
- Confirmed that the reader is properly closed or times out as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4b231213-0e74-44e0-b646-c67f814a0486