### PR TITLE
Fix Stop Command to Properly Shutdown Java Proxy with Reason

### DIFF
--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -175,18 +175,22 @@ func (g *Gate) Stop() {
 
 // StopWithReason stops the Gate and, if provided, disconnects players with the given reason.
 func (g *Gate) StopWithReason(reason component.Component) {
-	if g == nil {
-		return
-	}
+    if g == nil {
+        return
+    }
+    // Proactively shut down the Java proxy with the provided reason.
+    // This ensures connected players receive the console-specified message.
+    if jp := g.Java(); jp != nil {
+        jp.Shutdown(reason)
+    }
 
-	// Cancel runtime context first so background processes can begin shutting down.
-	g.Stop()
+    // Cancel runtime context so remaining runnables wind down.
+    g.Stop()
 
-	if bedrock := g.Bedrock(); bedrock != nil {
-		bedrock.Stop()
-	}
-
-	_ = reason // reason is currently unused for proxy shutdown.
+    // Stop Bedrock (does not support a custom disconnect reason here).
+    if bedrock := g.Bedrock(); bedrock != nil {
+        bedrock.Stop()
+    }
 }
 
 func (g *Gate) setStop(cancel context.CancelFunc) {


### PR DESCRIPTION
## Summary
- Fixes the `StopWithReason` method in the Gate to properly shutdown the Java proxy with a provided reason.
- Prevents blocking on Windows when closing the console reader by making it asynchronous with a timeout.

## Changes

### Gate Stop Logic
- Modified `StopWithReason` to proactively call `Shutdown(reason)` on the Java proxy before stopping the Gate.
- Ensures connected players receive the console-specified disconnect reason.
- Retains stopping of Bedrock proxy without a custom reason.

### Console Reader Close
- Updated `closeReader` to close the console reader asynchronously.
- Added a 250ms timeout to avoid long blocking on Windows during reader close.
- Added early return if reader is nil to prevent unnecessary operations.

## Test plan
- Verified that the Java proxy receives the shutdown reason and disconnects players accordingly.
- Confirmed that the Gate stops cleanly and Bedrock proxy stops as expected.
- Tested console reader close on Windows to ensure it does not block the shutdown process.
- Checked that no panics or errors occur when reader is nil during close.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4b231213-0e74-44e0-b646-c67f814a0486