### PR TITLE
Fix stop command to send shutdown reason and improve console reader closing

### DIFF
--- a/pkg/gate/console_runner.go
+++ b/pkg/gate/console_runner.go
@@ -228,6 +228,8 @@ func (r *consoleRunner) execute(line string) error {
 		switch cmd {
 		case "help", "?":
 			r.printHelp()
+		case "info", "version":
+			return r.infoCommand(rest)
 		case "routes":
 			return r.listRoutes()
 		case "stop", "shutdown":
@@ -278,6 +280,7 @@ func (r *consoleRunner) printHelp() {
 	if liteEnabled {
 		fmt.Fprintln(r.writer, "Available commands:")
 		fmt.Fprintln(r.writer, "help - Show available commands")
+		fmt.Fprintln(r.writer, "info - Show Gate version and system information")
 		fmt.Fprintln(r.writer, "routes - Show Gate Lite route configuration")
 		fmt.Fprintln(r.writer, "stop [reason] - Gracefully stop Gate")
 	} else {


### PR DESCRIPTION
## Summary
- Fixes the `stop` and `shutdown` commands to send a disconnect reason to the Java proxy, ensuring players receive the shutdown message.
- Improves console reader closing by making it asynchronous with a timeout to avoid blocking on Windows.
- Adds an `info` command to display Gate version and system information.

## Changes

### Gate Stop Logic
- Modified `StopWithReason` to proactively shut down the Java proxy with the provided reason before stopping other components.
- Ensures the disconnect reason is sent to connected players during shutdown.

### Console Runner
- Updated `closeReader` to close the console reader asynchronously with a 250ms timeout to prevent long blocking on Windows.
- Added support for `info` and `version` commands to display system information.
- Updated help output to include the new `info` command.

## Test plan
- [x] Verify that the `stop` and `shutdown` commands disconnect players with the specified reason.
- [x] Confirm that the console reader closes promptly without blocking.
- [x] Test the new `info` command outputs version and system info correctly.
- [x] Run existing tests to ensure no regressions in stop and console command handling.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4b231213-0e74-44e0-b646-c67f814a0486