### PR TITLE
Fix MOTD passthrough fallback and add Try list support

### DIFF
--- a/config-bedrock.yml
+++ b/config-bedrock.yml
@@ -5,6 +5,7 @@ config:
     server1: 0.0.0.0:25566
   try:
     - server1
+  tryPassthroughMotd: false
   # forwarding:
   # mode: legacy
   # velocitySecret: 'bedrock-crossplay-secret'

--- a/config-simple.yml
+++ b/config-simple.yml
@@ -9,3 +9,4 @@ config:
   try:
     - server1
     - server2
+  tryPassthroughMotd: false

--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,8 @@ config:
     - server2
     - server3
     - server4
+  # Whether MOTD passthrough should consider the Try list when resolving ping responses.
+  tryPassthroughMotd: false
   # Configure the response for server list pings.
   status:
     # The message of the day in legacy '§' format or modern text component '{"text":"...", ...}' json.

--- a/pkg/edition/java/config/config.go
+++ b/pkg/edition/java/config/config.go
@@ -39,6 +39,7 @@ var DefaultConfig = Config{
 	AnnounceForge:                        false,
 	Servers:                              ServerConfigs{},
 	Try:                                  []string{},
+	TryPassthroughMotd:                   false,
 	ForcedHosts:                          map[string][]string{},
 	FailoverOnUnexpectedServerDisconnect: true,
 	ConnectionTimeout:                    configutil.Duration(5000 * time.Millisecond),
@@ -99,6 +100,7 @@ type Config struct { // TODO use https://github.com/projectdiscovery/yamldoc-go 
 
 	Servers                              ServerConfigs `yaml:"servers,omitempty" json:"servers,omitempty"` // name:ServerConfig or name:address
 	Try                                  []string          `yaml:"try,omitempty" json:"try,omitempty"`         // Try server names order
+	TryPassthroughMotd                   bool              `yaml:"tryPassthroughMotd,omitempty" json:"tryPassthroughMotd,omitempty"`
 	ForcedHosts                          ForcedHosts       `yaml:"forcedHosts,omitempty" json:"forcedHosts,omitempty"`
 	FailoverOnUnexpectedServerDisconnect bool              `yaml:"failoverOnUnexpectedServerDisconnect,omitempty" json:"failoverOnUnexpectedServerDisconnect,omitempty"`
 

--- a/pkg/edition/java/proxy/motd_passthrough.go
+++ b/pkg/edition/java/proxy/motd_passthrough.go
@@ -119,36 +119,37 @@ func (p *Proxy) resolveMOTDPassthrough(
 	}
 }
 
-// findPassthroughServer finds the server with MOTD passthrough enabled, following the same priority order
-// as player connections: forcedHosts first (based on virtual host), then Try section, then all servers.
+// findPassthroughServer finds the server with MOTD passthrough enabled following the player routing rules:
+// forcedHosts first (based on virtual host), then the Try section when passthrough via Try is enabled.
 func (p *Proxy) findPassthroughServer(virtualHost net.Addr) (*config.ServerConfig, string) {
 	cfg := p.config()
 
 	// Get the hostname from virtual host for forced hosts lookup
-	var serversToTry []string
 	if virtualHost != nil {
 		virtualHostStr := p.getVirtualHostnameFromAddr(virtualHost)
 		if virtualHostStr != "" {
-			serversToTry = cfg.ForcedHosts[virtualHostStr]
+			if forcedServers := cfg.ForcedHosts[virtualHostStr]; len(forcedServers) > 0 {
+				if serverCfg, name := findFirstPassthrough(cfg.Servers, forcedServers); serverCfg != nil {
+					return serverCfg, name
+				}
+			}
 		}
 	}
 
-	// If no forced hosts match, fall back to Try list
-	if len(serversToTry) == 0 {
-		serversToTry = cfg.Try
-	}
-
-	// Check servers in priority order first
-	for _, serverName := range serversToTry {
-		if serverConfig, exists := cfg.Servers[serverName]; exists && serverConfig.PassthroughMOTD {
-			return &serverConfig, serverName
+	if cfg.TryPassthroughMotd {
+		if serverCfg, name := findFirstPassthrough(cfg.Servers, cfg.Try); serverCfg != nil {
+			return serverCfg, name
 		}
 	}
 
-	// If no priority servers have passthrough, check all servers as fallback
-	for serverName, serverConfig := range cfg.Servers {
-		if serverConfig.PassthroughMOTD {
-			return &serverConfig, serverName
+	return nil, ""
+}
+
+func findFirstPassthrough(servers config.ServerConfigs, names []string) (*config.ServerConfig, string) {
+	for _, serverName := range names {
+		if serverConfig, exists := servers[serverName]; exists && serverConfig.PassthroughMOTD {
+			server := serverConfig
+			return &server, serverName
 		}
 	}
 

--- a/pkg/edition/java/proxy/motd_passthrough_test.go
+++ b/pkg/edition/java/proxy/motd_passthrough_test.go
@@ -101,11 +101,11 @@ func TestGetErrorVerbosity(t *testing.T) {
 
 func TestFindPassthroughServer(t *testing.T) {
 	tests := []struct {
-		name                    string
-		setupConfig            func() *config.Config
-		virtualHost            string // hostname for testing forced hosts
-		expectedServerName     string
-		expectedServerConfig   *config.ServerConfig
+		name                  string
+		setupConfig           func() *config.Config
+		virtualHost           string // hostname for testing forced hosts
+		expectedServerName    string
+		expectedServerConfig  *config.ServerConfig
 	}{
 		{
 			name: "finds server from forcedHosts when virtual host matches",
@@ -118,13 +118,13 @@ func TestFindPassthroughServer(t *testing.T) {
 					},
 					Try: []string{"fabric", "vanilla"},
 					ForcedHosts: map[string][]string{
-						"snapshot.miniverse.fr": {"vanilla"},
-						"fabric.miniverse.fr":   {"fabric"},
-						"forge.miniverse.fr":    {"neoforge"},
+						"snapshot.example.test": {"vanilla"},
+						"fabric.example.test":   {"fabric"},
+						"forge.example.test":    {"neoforge"},
 					},
 				}
 			},
-			virtualHost:        "snapshot.miniverse.fr:25565",
+			virtualHost:        "snapshot.example.test:25565",
 			expectedServerName: "vanilla",
 			expectedServerConfig: &config.ServerConfig{
 				Address:         "localhost:25566",
@@ -132,7 +132,7 @@ func TestFindPassthroughServer(t *testing.T) {
 			},
 		},
 		{
-			name: "falls back to Try list when virtual host doesn't match forcedHosts",
+			name: "falls back to Try list when enabled and virtual host doesn't match forcedHosts",
 			setupConfig: func() *config.Config {
 				return &config.Config{
 					Servers: config.ServerConfigs{
@@ -140,9 +140,10 @@ func TestFindPassthroughServer(t *testing.T) {
 						"fabric":   {Address: "localhost:25567", PassthroughMOTD: true},
 						"neoforge": {Address: "localhost:25568", PassthroughMOTD: true},
 					},
-					Try: []string{"fabric", "vanilla"},
+					Try:                []string{"fabric", "vanilla"},
+					TryPassthroughMotd: true,
 					ForcedHosts: map[string][]string{
-						"snapshot.miniverse.fr": {"vanilla"},
+						"snapshot.example.test": {"vanilla"},
 					},
 				}
 			},
@@ -154,7 +155,7 @@ func TestFindPassthroughServer(t *testing.T) {
 			},
 		},
 		{
-			name: "finds first server in Try list with passthrough enabled (no virtual host)",
+			name: "finds first server in Try list with passthrough enabled when option is true",
 			setupConfig: func() *config.Config {
 				return &config.Config{
 					Servers: config.ServerConfigs{
@@ -162,7 +163,8 @@ func TestFindPassthroughServer(t *testing.T) {
 						"server2": {Address: "localhost:25562", PassthroughMOTD: true},
 						"server3": {Address: "localhost:25563", PassthroughMOTD: true},
 					},
-					Try: []string{"server2", "server3"},
+					Try:                []string{"server2", "server3"},
+					TryPassthroughMotd: true,
 				}
 			},
 			virtualHost:        "", // No virtual host
@@ -171,6 +173,22 @@ func TestFindPassthroughServer(t *testing.T) {
 				Address:         "localhost:25562",
 				PassthroughMOTD: true,
 			},
+		},
+		{
+			name: "returns nil when Try list passthrough is disabled",
+			setupConfig: func() *config.Config {
+				return &config.Config{
+					Servers: config.ServerConfigs{
+						"server1": {Address: "localhost:25561", PassthroughMOTD: false},
+						"server2": {Address: "localhost:25562", PassthroughMOTD: true},
+					},
+					Try:                []string{"server2"},
+					TryPassthroughMotd: false,
+				}
+			},
+			virtualHost:          "",
+			expectedServerName:   "",
+			expectedServerConfig: nil,
 		},
 		{
 			name: "returns nil when no servers have passthrough enabled",
@@ -188,23 +206,21 @@ func TestFindPassthroughServer(t *testing.T) {
 			expectedServerConfig: nil,
 		},
 		{
-			name: "falls back to any server with passthrough if Try list servers don't have it",
+			name: "returns nil when only non-Try servers have passthrough",
 			setupConfig: func() *config.Config {
 				return &config.Config{
 					Servers: config.ServerConfigs{
-						"server1":      {Address: "localhost:25561", PassthroughMOTD: false},
-						"server2":      {Address: "localhost:25562", PassthroughMOTD: false},
-						"fallback":     {Address: "localhost:25563", PassthroughMOTD: true},
+						"server1":  {Address: "localhost:25561", PassthroughMOTD: false},
+						"server2":  {Address: "localhost:25562", PassthroughMOTD: false},
+						"fallback": {Address: "localhost:25563", PassthroughMOTD: true},
 					},
-					Try: []string{"server1", "server2"},
+					Try:                []string{"server1", "server2"},
+					TryPassthroughMotd: true,
 				}
 			},
-			virtualHost:        "",
-			expectedServerName: "fallback",
-			expectedServerConfig: &config.ServerConfig{
-				Address:         "localhost:25563",
-				PassthroughMOTD: true,
-			},
+			virtualHost:          "",
+			expectedServerName:   "",
+			expectedServerConfig: nil,
 		},
 		{
 			name: "returns nil when no servers exist",
@@ -226,18 +242,38 @@ func TestFindPassthroughServer(t *testing.T) {
 						"vanilla": {Address: "localhost:25566", PassthroughMOTD: false}, // No passthrough
 						"fabric":  {Address: "localhost:25567", PassthroughMOTD: true},
 					},
-					Try: []string{"fabric"},
+					Try:                []string{"fabric"},
+					TryPassthroughMotd: true,
 					ForcedHosts: map[string][]string{
-						"snapshot.miniverse.fr": {"vanilla"}, // This server doesn't have passthrough
+						"snapshot.example.test": {"vanilla"}, // This server doesn't have passthrough
 					},
 				}
 			},
-			virtualHost:        "snapshot.miniverse.fr:25565",
+			virtualHost:        "snapshot.example.test:25565",
 			expectedServerName: "fabric", // Should fall back to Try list
 			expectedServerConfig: &config.ServerConfig{
 				Address:         "localhost:25567",
 				PassthroughMOTD: true,
 			},
+		},
+		{
+			name: "returns nil when forcedHost lacks passthrough and Try passthrough disabled",
+			setupConfig: func() *config.Config {
+				return &config.Config{
+					Servers: config.ServerConfigs{
+						"vanilla": {Address: "localhost:25566", PassthroughMOTD: false},
+						"fabric":  {Address: "localhost:25567", PassthroughMOTD: true},
+					},
+					Try:                []string{"fabric"},
+					TryPassthroughMotd: false,
+					ForcedHosts: map[string][]string{
+						"snapshot.example.test": {"vanilla"},
+					},
+				}
+			},
+			virtualHost:          "snapshot.example.test:25565",
+			expectedServerName:   "",
+			expectedServerConfig: nil,
 		},
 	}
 
@@ -351,13 +387,13 @@ func TestGetVirtualHostnameFromAddr(t *testing.T) {
 	}{
 		{
 			name:         "extracts hostname from address with port",
-			virtualHost:  &testNetAddr{address: "snapshot.miniverse.fr:25565"},
-			expectedHost: "snapshot.miniverse.fr",
+			virtualHost:  &testNetAddr{address: "snapshot.example.test:25565"},
+			expectedHost: "snapshot.example.test",
 		},
 		{
 			name:         "extracts hostname from address without port",
-			virtualHost:  &testNetAddr{address: "fabric.miniverse.fr"},
-			expectedHost: "fabric.miniverse.fr",
+			virtualHost:  &testNetAddr{address: "fabric.example.test"},
+			expectedHost: "fabric.example.test",
 		},
 		{
 			name:         "handles localhost",

--- a/test-improved-ping-passthrough.yml
+++ b/test-improved-ping-passthrough.yml
@@ -14,7 +14,8 @@ config:
   try:
     - fabric     # With the improved logic, this will be used for the default domain (not forced hosts)
     - vanilla
+  tryPassthroughMotd: true
   forcedHosts:
-    "snapshot.miniverse.fr": ["vanilla"]
-    "fabric.miniverse.fr": ["fabric"]
-    "forge.miniverse.fr": ["neoforge"]
+    "snapshot.example.test": ["vanilla"]
+    "fabric.example.test": ["fabric"]
+    "forge.example.test": ["neoforge"]


### PR DESCRIPTION
## Summary
- Fixes MOTD passthrough server selection logic to respect the new `tryPassthroughMotd` configuration option.
- Adds support for considering the `Try` server list when resolving MOTD passthrough if enabled.
- Updates configuration files and defaults to include `tryPassthroughMotd` flag.
- Improves test coverage for MOTD passthrough server resolution with various scenarios.

## Changes

### Configuration
- Added `tryPassthroughMotd` boolean flag to config files (`config.yml`, `config-bedrock.yml`, `config-simple.yml`) and default config struct.
- This flag controls whether the MOTD passthrough logic should consider the `Try` list when selecting a server.

### MOTD Passthrough Logic
- Refactored `findPassthroughServer` to:
  - First check forced hosts for passthrough-enabled servers.
  - Then check the `Try` list if `tryPassthroughMotd` is enabled.
  - Return nil if no suitable server is found (no longer falls back to all servers).
- Added helper `findFirstPassthrough` to find the first passthrough-enabled server in a given list.

### Tests
- Updated `TestFindPassthroughServer` to cover:
  - Forced hosts passthrough.
  - Try list passthrough when enabled.
  - Disabled Try passthrough returns nil.
  - No fallback to non-Try servers even if they have passthrough enabled.
  - Various edge cases with empty servers or no passthrough enabled.
- Fixed test hostnames to use example domains.

### Miscellaneous
- Updated test and example config files to reflect new option and example hostnames.

## Test plan
- [x] Run existing and new unit tests for MOTD passthrough logic.
- [x] Verify configuration loading includes `tryPassthroughMotd`.
- [x] Manual testing with different config setups to confirm correct MOTD passthrough server selection.

This change improves the MOTD passthrough feature by making it respect the `Try` server list optionally, aligning it with player routing rules and avoiding unintended fallback to all servers.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e9c8d49b-179d-4a63-b4df-c91c2d5e74a5